### PR TITLE
Support jQuery with noConflict()

### DIFF
--- a/guider.js
+++ b/guider.js
@@ -13,7 +13,7 @@
  * Enjoy!
  */
 
-var guider = (function(){
+var guider = (function($){
   var guider = {
     _defaultSettings: {
       attachTo: null,
@@ -295,4 +295,4 @@ var guider = (function(){
   };
 
   return guider;
-}).call(this);
+}).call(this, jQuery);


### PR DESCRIPTION
Don't assume the global $ exists and it's jQuery – pass jQuery as an argument and use $ internally only.
