### PR TITLE
Scrolls the guider into view on show if needed

### DIFF
--- a/guider.js
+++ b/guider.js
@@ -289,6 +289,16 @@ var guider = (function(){
       }
       guider._attach(myGuider);
       myGuider.elem.fadeIn("fast");
+
+      height = $(window).height();
+      scroll = $(window).scrollTop();
+      offset = myGuider.elem.offset();
+      elemHeight = myGuider.elem.height();
+
+      if (offset.top - scroll < 0 || offset.top + elemHeight + 40 > scroll + height) {
+        window.scrollTo(0, Math.max(offset.top + (elemHeight / 2) - (height / 2), 0));
+      }
+
       guider._currentGuiderID = id;
       return guider;
     }


### PR DESCRIPTION
When using attachTo on a page with scroll, there's a risk of the guider getting displayed
outside of the viewport. This commit makes sure the window scrolls to center on the guider
in that case
