### PR TITLE
Adding a method to find guiders by a given ID

### DIFF
--- a/guider.js
+++ b/guider.js
@@ -268,6 +268,17 @@ var guider = (function(){
       return guider;
     },
 
+    /* 
+     * Locate a guider with the supplied id. Returns null if no guider exists.
+     */
+    findGuider: function(id) {
+      try {
+        return _guiderById(id);
+      } catch {
+        return null;  // could not find guider.
+      }
+    },
+
     hideAll: function(omitHidingOverlay) {
       $(".guider").fadeOut("fast");
       if (typeof omitHidingOverlay !== "undefined" && omitHidingOverlay === true) {


### PR DESCRIPTION
One thing we're using the guiders project for is dynamically loading guiders from an AJAX call (in cases where pulling the data for the guider might be heavy or rarely used). When that happens, it's helpful to see if the guider exists before we add it to the collection - I added a little method to find a guider by ID (which just calls the private method but returns null if it's not found).
