### PR TITLE
Don't trigger a js error if the attachTo selector finds nothing. 

### DIFF
--- a/guiders-1.1.1.js
+++ b/guiders-1.1.1.js
@@ -110,6 +110,10 @@ var guiders = (function($){
       }
 
       myGuider.attachTo = $(myGuider.attachTo);
+      if (!myGuider.attachTo.length) {
+          return false;
+      }
+
       var base = myGuider.attachTo.offset();
       var attachToHeight = myGuider.attachTo.innerHeight();
       var attachToWidth = myGuider.attachTo.innerWidth();


### PR DESCRIPTION
If e.g. attachTo is #notonthepageyet you'll see:

```
`Uncaught TypeError: Cannot read property 'top' of null`
```

This simple change prevents that.
