### PR TITLE
Skip guider if attachTo is not visible on the page.

### DIFF
--- a/guiders-1.1.2.js
+++ b/guiders-1.1.2.js
@@ -257,7 +257,7 @@ var guiders = (function($){
       if (nextGuiderId !== null && nextGuiderId !== "") {
         var myGuider = guiders._guiderById(nextGuiderId);
         // Ensure myGuider.attachTo is present on the page. Else, skip to next guider.
-        if (typeof myGuider.attachTo !== "undefined" && $(myGuider.attachTo).size() === 0) {
+        if (typeof myGuider.attachTo !== "undefined" && !$(myGuider.attachTo).is(':visible')) {
           guiders._currentGuiderID = myGuider.id;
           guiders.next();
           return;


### PR DESCRIPTION
It would be nice to skip showing a Guider altogether if it has an `attachTo` specified but the element is not visible in the page.

This would be useful if you have a dynamically changing page and you have a predefined list of guiders to show on the page. Currently if attachTo is not present on the page, the guider popup appears at the bottom of the page.
