### PR TITLE
Fix for TypeError being thrown when position is set, but no attachTo element is defined.

### DIFF
--- a/guiders-1.1.2.js
+++ b/guiders-1.1.2.js
@@ -96,14 +96,14 @@ var guiders = (function($){
     },
 
     _attach: function(myGuider) {
-      if (typeof myGuider.attachTo === "undefined" || myGuider === null) {
+      if (myGuider === null) {
         return;
       }
 
       var myHeight = myGuider.elem.innerHeight();
       var myWidth = myGuider.elem.innerWidth();
 
-      if (myGuider.position === 0) {
+      if (myGuider.position === 0 || myGuider.attachTo === null) {
         myGuider.elem.css("position", "absolute");
         myGuider.elem.css("top", ($(window).height() - myHeight) / 3 + $(window).scrollTop() + "px");
         myGuider.elem.css("left", ($(window).width() - myWidth) / 2 + $(window).scrollLeft() + "px");


### PR DESCRIPTION
I realize this is not the intended use, but then again, TypeErros are simply not cool this season ;)

The _attachTo_ property is never undefined, because it is set as null @ L23. If it is not set, ignore position and center the guider.
