### PR TITLE
Fix for removing empty button container when there is no buttons.

### DIFF
--- a/guiders-1.1.3.js
+++ b/guiders-1.1.3.js
@@ -91,6 +91,10 @@ var guiders = (function($){
         var myCustomHTML = $(myGuider.buttonCustomHTML);
         myGuider.elem.find(".guider_buttons").append(myCustomHTML);
       }
+
+			if (myGuider.buttons.length == 0) {
+				guiderButtonsContainer.remove();
+			}
     },
 
     _addXButton: function(myGuider) {


### PR DESCRIPTION
When using guiders without any buttons the button container is still there and takes up space.
