### PR TITLE
Fixes an issue were the jQueryized version of the attachTo was being leaked back to the main version of the object.

### DIFF
--- a/guiders-1.2.0.js
+++ b/guiders-1.2.0.js
@@ -127,10 +127,10 @@ var guiders = (function($) {
       return;
     }
     
-    myGuider.attachTo = $(myGuider.attachTo);
-    var base = myGuider.attachTo.offset();
-    var attachToHeight = myGuider.attachTo.innerHeight();
-    var attachToWidth = myGuider.attachTo.innerWidth();
+    var attachTo = $(myGuider.attachTo);
+    var base = attachTo.offset();
+    var attachToHeight = attachTo.innerHeight();
+    var attachToWidth = attachTo.innerWidth();
     
     var top = base.top;
     var left = base.left;


### PR DESCRIPTION
This caused issues if the attachTo element was not initially on the page when the guider was created, but later was added to the page. Because this code was originally replacing the guider.attachTo with the jQuery version (which is empty for non-existent elements) if you later added the element to the page, the guider had nothing to attach to.
