### PR TITLE
highlight option now works for elements with CSS position 'static'

### DIFF
--- a/guiders-1.2.0.js
+++ b/guiders-1.2.0.js
@@ -190,6 +190,9 @@ var guiders = (function($) {
   };
 
   guiders._highlightElement = function(selector) {
+    if ($(selector).css('position') == 'static') {
+        $(selector).css('position', 'relative');
+    }
     $(selector).css({'z-index': guiders._zIndexForHighlight});
   };
 


### PR DESCRIPTION
Previously, elements specified in the 'highlight' option were not actually highlighted.  The code only ups their z-index, which has no effect on statically-positioned elements.

As there is practically little difference between 'static' and 'relative' positioning (I know there is a difference, but in common usage, problems rarely arise), I decided that it is safe enough to force relative positioning upon highlighting.

Note:  I do not revert the position back to 'static' after de-highlighting, as this entails remembering that it was indeed originally static, and doing so doesn't seem to offer significant benefit.
