### PR TITLE
Continue when attachTo element couldn't be found.

### DIFF
--- a/guiders-1.2.2.js
+++ b/guiders-1.2.2.js
@@ -128,6 +128,9 @@ var guiders = (function($) {
     }
     
     var attachTo = $(myGuider.attachTo);
+    if(attachTo.length == 0) {
+      return;
+    }
     var base = attachTo.offset();
     var attachToHeight = attachTo.innerHeight();
     var attachToWidth = attachTo.innerWidth();


### PR DESCRIPTION
Hi,
I have following issue:

I have multiple guiders on one page, opened by some events. So when their attachTo element cannot be found, it is not an issue.

So my patch just skips attaching to element, when it couldn't be found.

Does it fit your workflow?
