### PR TITLE
Character entities in button captions

### DIFF
--- a/guiders-1.2.3.js
+++ b/guiders-1.2.3.js
@@ -75,7 +75,7 @@ var guiders = (function($) {
       var thisButton = myGuider.buttons[i];
       var thisButtonElem = $("<a></a>", {
                               "class" : "guider_button",
-                              "text" : thisButton.name });
+                              "html" : thisButton.name });
       if (typeof thisButton.classString !== "undefined" && thisButton.classString !== null) {
         thisButtonElem.addClass(thisButton.classString);
       }


### PR DESCRIPTION
Hi there,

small change in the button creation: I'd use "html" instead of "text" for the caption - otherwise character entities are getting escaped and are not rendered correctly.
E.g. "&uuml;" should become "ü"; with "text" it becomes "&amp;uuml;"

From what I can see so far it doesn't break something else, but I'm not really sure.

Thanks - for guiders and for considering the patch,
Wolfgang
