### PR TITLE
lock element after clicking (this prevents accidental doubleclicks)

### DIFF
--- a/guiders-1.2.3.js
+++ b/guiders-1.2.3.js
@@ -89,7 +89,7 @@ var guiders = (function($) {
         thisButtonElem.bind("click", function() { guiders.hideAll(); });
       } else if (!thisButton.onclick &&
                  thisButton.name.toLowerCase() === guiders._nextButtonTitle.toLowerCase()) { 
-        thisButtonElem.bind("click", function() { guiders.next(); });
+        thisButtonElem.bind("click", function() { !myGuider.elem.data('locked') && guiders.next(); });
       }
     }
   
@@ -280,6 +280,8 @@ var guiders = (function($) {
     if (typeof currentGuider === "undefined") {
       return;
     }
+    currentGuider.elem.data('locked', true);
+
     var nextGuiderId = currentGuider.next || null;
     if (nextGuiderId !== null && nextGuiderId !== "") {
       var myGuider = guiders._guiderById(nextGuiderId);
@@ -389,7 +391,7 @@ var guiders = (function($) {
 
     guiders._attach(myGuider);
   
-    myGuider.elem.fadeIn("fast");
+    myGuider.elem.fadeIn("fast").data('locked', false);
   
     var windowHeight = $(window).height();
     var scrollHeight = $(window).scrollTop();


### PR DESCRIPTION
I found a following issue:
- user accidentaly doubleclicks next button
- guiders skips two steps

So this patch adds lock to guider element. So click to next works only on shown elements.
