### PR TITLE
Allow custom buttons & fire event after guider is shown

### DIFF
--- a/guiders-1.2.3.js
+++ b/guiders-1.2.3.js
@@ -406,6 +406,8 @@ var guiders = (function($) {
     }
   
     guiders._currentGuiderID = id;
+    $(myGuider.elem).trigger('guiders.show');
+
     return guiders;
   };
   


### PR DESCRIPTION
Hi!
I found one "issue" with guiders. We wanted keyboard navigation, to show new guider.

So I've implemented following:
- allow custom element for guider button (we use button)
- allow custom attributes for guider button (with href = # as default)
- allow custom attributes for button on guider level

With this, I was able to implement navigation by pressing spacebar or enter. After guider is shown, next button is focused, so user can use keyboard.

```
$(document).on('guiders.show', '.guider', function(){
  $('.guider_button:contains(Next), .guider_button[rel=next]', this).focus();
});
```

```
guiders.createGuider({ ...
    buttons: [{name: 'Some text', html: {rel: 'next'}}]
```
