### PR TITLE
make guiders.showAll always work

### DIFF
--- a/guiders-1.2.3.js
+++ b/guiders-1.2.3.js
@@ -357,7 +357,7 @@ var guiders = (function($) {
     });
     $(".guider").fadeOut("fast");
     var currentGuider = guiders._guiders[guiders._currentGuiderID];
-    if (currentGuider.highlight) {
+    if (currentGuider && currentGuider.highlight) {
     	guiders._dehighlightElement(currentGuider.highlight);
     }
     if (typeof omitHidingOverlay !== "undefined" && omitHidingOverlay === true) {


### PR DESCRIPTION
If `guiders.showAll()` is called before a `guiders.show()`, it gives an error.
