### PR TITLE
Enabled specifying guider appendTo location

### DIFF
--- a/guiders-1.2.6.js
+++ b/guiders-1.2.6.js
@@ -483,7 +483,9 @@ var guiders = (function($) {
     }
     _resizing = setTimeout(function() {
       _resizing = undefined;
-      guiders.reposition();
+      if (typeof (myGuider) !== "undefined") {
+	     guiders.reposition();
+	  }
     }, 20);
   });
   


### PR DESCRIPTION
Gives the programmer the ability to choose other than 'body' the
location the guider should be appended to.
