### PR TITLE
Fix exception in _attach

### DIFF
--- a/guiders-1.2.6.js
+++ b/guiders-1.2.6.js
@@ -159,7 +159,7 @@ var guiders = (function($) {
     
     // topMarginOfBody corrects positioning if body has a top margin set on it.
     var topMarginOfBody = $("body").outerHeight(true) - $("body").outerHeight(false);
-    base -= topMarginOfBody;
+    top -= topMarginOfBody;
 
     // Now, take into account how the guider should be positioned relative to the attachTo element.
     // e.g. top left, bottom center, etc.


### PR DESCRIPTION
If resize fires before the current guider is fully shown myGuider is
"undefined" which doesn't match null
