### PR TITLE
Make guiders attach to window object more reliably

### DIFF
--- a/guiders-1.3.0.js
+++ b/guiders-1.3.0.js
@@ -18,8 +18,8 @@
  * Enjoy!
  */
 
-var guiders = (function($) {
-  var guiders = {};
+(function($) {
+  var guiders = this.guiders = {};
   
   guiders.version = "1.3.0";
 


### PR DESCRIPTION
This fix ensures that the guiders object attaches to window correctly in more cases.

Previously if a build tool such as require.js wrapped the guiders.js contents in a closure then the "guiders" object would not be available outside that closure
