### PR TITLE
Fix IE regex literal to handle IE 10.

### DIFF
--- a/guiders.js
+++ b/guiders.js
@@ -89,7 +89,7 @@ var guiders = (function($) {
   guiders._windowHeight = 0;
   
   // Basic IE browser detection
-  var ieBrowserMatch = navigator.userAgent.match('MSIE (.)');
+  var ieBrowserMatch = navigator.userAgent.match(/MSIE\s([\d.]+)/);
   guiders._isIE = ieBrowserMatch && ieBrowserMatch.length > 1;
   guiders._ieVersion = ieBrowserMatch && ieBrowserMatch.length > 1 ? Number(ieBrowserMatch[1]) : -1;
   


### PR DESCRIPTION
- Uses the regex recommended at https://blogs.msdn.com/b/ie/archive/2011/04/15/the-ie10-user-agent-string.aspx
