### PR TITLE
Remove title if it's empty

### DIFF
--- a/guiders-1.3.0.js
+++ b/guiders-1.3.0.js
@@ -452,6 +452,10 @@ var guiders = (function($) {
     
     var guiderTitleContainer = guiderElement.find(".guiders_title");
     guiderTitleContainer.html(myGuider.title);
+    // only show title if it has content
+    if (myGuider.title == "") {
+      guiderTitleContainer.remove();
+    }
     
     guiderElement.find(".guiders_description").html(myGuider.description);
     


### PR DESCRIPTION
title parameter could be made optional by removing it if the string is empty. This allows guiders to be better used for shorter popups.
