### PR TITLE
fix for wp7.5 bug where clicks go through the overlay

### DIFF
--- a/guiders.js
+++ b/guiders.js
@@ -271,7 +271,7 @@ var guiders = (function($) {
 
   guiders._initializeOverlay = function() {
     if ($("#guiders_overlay").length === 0) {
-      $("<div id='guiders_overlay'></div>").hide().appendTo("body");
+      $("<div id='guiders_overlay' onclick='return false;'></div>").hide().appendTo("body");
     }
   };
 


### PR DESCRIPTION
Tested that solution proposed at http://stackoverflow.com/questions/8641313/how-can-prevent-the-click-on-elements-which-under-the-transparent-overlay-div-in works with Windows phone 7.5
