### PR TITLE
updated the show method to respect the shoudlSkip method if it's defined

### DIFF
--- a/guiders.js
+++ b/guiders.js
@@ -576,6 +576,13 @@ var guiders = (function($) {
     }
   
     var myGuider = guiders.get(id);
+
+    if (myGuider.shouldSkip && myGuider.shouldSkip()) {
+      guiders._currentGuiderID = id;
+      guiders.next();
+      return guiders;
+    }
+    
     if (myGuider.overlay) {
       guiders._showOverlay();
       // if guider is attached to an element, make sure it's visible


### PR DESCRIPTION
My thought was that you should use show() with the earliest potential guider and leverage the shouldShow functionality that's already part of the individual guiders and not recreate it elsewhere.
