### PR TITLE
Fix highlight

### DIFF
--- a/guiders.js
+++ b/guiders.js
@@ -580,7 +580,7 @@ var guiders = (function($) {
       guiders._showOverlay(myGuider);
       // if guider is attached to an element, make sure it's visible
       if (myGuider.highlight && myGuider.attachTo) {
-        guiders._highlightElement(myGuider.attachTo);
+        guiders._highlightElement(myGuider.highlight);
       }
     }
     


### PR DESCRIPTION
Highlighting was applied to the element that was mentioned in attachTo
instead of the element that was mentioned in highlight. This is now set
right.
