### PR TITLE
Fix skipping on previous

### DIFF
--- a/guiders.js
+++ b/guiders.js
@@ -544,8 +544,14 @@ var guiders = (function($) {
       if (prevGuider && prevGuider.highlight) {
         guiders._dehighlightElement(prevGuider.highlight);
       }
-      guiders.show(prevGuiderId);
-      return myGuider;
+      if (prevGuider.shouldSkip && prevGuider.shouldSkip()) {
+        guiders._currentGuiderID = prevGuider.id;
+        guiders.prev();
+        return guiders.getCurrentGuider();
+      } else {
+        guiders.show(prevGuiderId);
+        return myGuider;
+      }
     }
   };
   


### PR DESCRIPTION
Ensure that when going through the guides backwards (via previous) steps
that evaluate to 'should be skipped' are actually skipped.
